### PR TITLE
fix linker issue on linux

### DIFF
--- a/source/stb/package.d
+++ b/source/stb/package.d
@@ -12,3 +12,9 @@ int binarySearch(int min, int max, int delegate(int) comp, bool lower = true)
 
 	return res;
 }
+
+static this()
+{
+    // To prevent linker from stripping the symbol
+    auto f = &compress_for_stb_image_write;
+}


### PR DESCRIPTION
force linker to include compress_for_stb_image_write #3 

original solution by [gecko0307](https://github.com/gecko0307).  
https://github.com/gecko0307/dagon/commit/05d415dd25d15012005c0601d0186d2785e95e44